### PR TITLE
Build static library by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ instr_data = custom_target('tables',
                            install: true,
                            install_dir: [get_option('includedir'), false])
 
-libdisarm64 = library('disarm64', 'classify.c', 'decode.c', 'encode.c', 'format.c', instr_data, install: true)
+libdisarm64 = static_library('disarm64', 'classify.c', 'decode.c', 'encode.c', 'format.c', instr_data, install: true)
 disarm64 = declare_dependency(link_with: libdisarm64,
                               include_directories: include_directories('.'),
                               sources: instr_data)


### PR DESCRIPTION
The readme recommends to link statically with this library, but the build system generates a shared library by default. This PR changes the build to generate a static library.

Thanks!