### PR TITLE
Fixes for cases of undefined behavior in generated code

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -2,9 +2,9 @@
 #include "disarm64.h"
 #include <stdint.h>
 
-static int64_t sext(uint64_t imm, unsigned bits) {
+static uint64_t sext(uint64_t imm, unsigned bits) {
   uint64_t sign = 1 << (bits - 1);
-  return imm & sign ? (imm ^ sign) - sign : imm;
+  return (int64_t)(imm & sign ? (imm ^ sign) - sign : imm);
 }
 
 static unsigned clz(uint32_t v, unsigned sz) {

--- a/decode.c
+++ b/decode.c
@@ -24,7 +24,8 @@ static uint64_t immlogical(unsigned sf, unsigned N, unsigned immr,
   unsigned esize = 1 << len;
   uint64_t welem = ((uint64_t)1 << (s + 1)) - 1;
   // ROR(welem, r) as bits(esize)
-  welem = (welem >> r) | (welem << (esize - r));
+  if (r != 64 && (esize - r) != 64)
+      welem = (welem >> r) | (welem << (esize - r));
   if (esize < 64)
     welem &= ((uint64_t)1 << esize) - 1;
   // Replicate(ROR(welem, r))

--- a/format.c
+++ b/format.c
@@ -283,7 +283,7 @@ void da64_format(const struct Da64Inst* ddi, char* buf128) {
     case DA_OP_UIMMSHIFT:
       end = da_strpcat4(end, "#0x", 3);
       end = da_strpcatuimmhex(end, ddi->ops[i].uimm16);
-      end = da_strpcat8(end, &", lsl, msl"[ddi->ops[i].immshift.mask * 5], 5);
+      end = da_strpcat8(end, &", lsl, msl  "[ddi->ops[i].immshift.mask * 5], 5);
       end = da_strpcatimmdecstr(end, ddi->ops[i].immshift.shift, 0);
       break;
     case DA_OP_IMMFLOAT: {

--- a/parse.py
+++ b/parse.py
@@ -323,7 +323,7 @@ class DecoderGenerator:
         ops = set(x[1:] for x in re.findall(r'@[a-zA-Z0-9_]+', decodestr))
         for de in desc:
             if de.name in ops:
-                ty = "int64_t" if de.flags == "s" else "uint64_t"
+                ty = "uint64_t" if de.flags == "s" else "uint64_t"
                 if de.fixed.mask == (1 << de.size) - 1:
                     val = f"{de.fixed.val}"
                 else:


### PR DESCRIPTION
When running the decoder with the sanitizer enabled, several cases of undefined behavior come up having to do with invalid shift amounts, and a buffer overflow in `format.c`. To reproduce, run `meson setup build -Db_sanitize=address,undefined` and then run `meson test -v` in the `build` directory.

There are three cases:

* In `immlogical` sometimes `welem` is shifted by 64, which is undefined behavior. I have removed this case by using a check.
* In generated code, sometimes signed immediates are shifted such that they overflow, which is undefined behavior. I have fixed this by changing them to unsigned values (`sext` still performs sign-extension by casting to `int64_t` but then returns a `uint64_t`.
* The `da_strpcat8` function assumes the buffer is at least 8 bytes, which is not the case for one of the strings it is used with in `format.c`. I simply added space characters to make the buffer large enough.

I believe these fixes maintain the same behavior as before -- all test cases still pass.