### PR TITLE
Fix value for Rt2 in LDXR/STXR encoding

### DIFF
--- a/desc.txt
+++ b/desc.txt
@@ -381,7 +381,7 @@
   # canonical encoding of LDXR/STXR-Rt2=11111 LDX*-Rs=11111
   desc: {2:size}0010000{1:L}{1:P}{5:Rs}{1:o0}{5:Rt2}{5:Rn|SP}{5:Rt}
   mnem: {L,o0:0,0=ST:0,1=STL:1,0=LD:1,1=LDA}X{P,size<1>:0,0=R:0,1=R:1,1=P}{size:0=B:1=H:2=W:3=X}
-  decode: {L,o0:0,0=st:0,1=stl:1,0=ld:1,1=lda}x{P,size<1>:0,0=r:0,1=r:1,1=p}{size:0=b:1=h:2=:3=} {L:0=OPreggp(@Rs, 0):1=} OPreggp(@Rt, @size==3) {P:0=:1=OPreggp(@Rt, @size==3)} OPmemsoff(@Rn, 0)
+  decode: {L,o0:0,0=st:0,1=stl:1,0=ld:1,1=lda}x{P,size<1>:0,0=r:0,1=r:1,1=p}{size:0=b:1=h:2=:3=} {L:0=OPreggp(@Rs, 0):1=} OPreggp(@Rt, @size==3) {P:0=:1=OPreggp(@Rt2, @size==3)} OPmemsoff(@Rn, 0)
   encmnem: {L,o0:0,0=ST:0,1=STL:1,0=LD:1,1=LDA}X{P,size:0,0=RBw:0,1=RHw:0,2=Rw:0,3=Rx:1,2=Pw:1,3=Px}
   encops: Rs={L:0=reggp:1=regzr} Rt=reggp Rt2={P:0=regzr:1=reggp} Rn=reggpsp
 [MEMNP]

--- a/test/decode-test.c
+++ b/test/decode-test.c
@@ -56,6 +56,14 @@ int main(void) {
     TESTF(DA64_HAVE_LSE, 0x08207c1f, DA64I_UNKNOWN, "") // Rt must be even
     TESTF(DA64_HAVE_LSE, 0x08217c1e, DA64I_UNKNOWN, "") // Rs must be even
     TESTF(DA64_HAVE_BF16, 0x1e634020, DA64I_BFCVT, "bfcvt h0, s1")
+    TEST(0x88231d25, DA64I_STXPW, "stxp w3, w5, w7, [x9]")
+    TEST(0x887f1d25, DA64I_LDXPW, "ldxp w5, w7, [x9]")
+    TEST(0xc8231d25, DA64I_STXPX, "stxp w3, x5, x7, [x9]")
+    TEST(0xc87f1d25, DA64I_LDXPX, "ldxp x5, x7, [x9]")
+    TEST(0x88037d25, DA64I_STXRW, "stxr w3, w5, [x9]")
+    TEST(0x885f7d25, DA64I_LDXRW, "ldxr w5, [x9]")
+    TEST(0xc8037d25, DA64I_STXRX, "stxr w3, x5, [x9]")
+    TEST(0xc85f7d25, DA64I_LDXRX, "ldxr x5, [x9]")
   // clang-format on
 
 #include "decode-test-branchreg.inc"


### PR DESCRIPTION
The slot for `Rt2` gets assigned to `Rt` due to a bug in `desc.txt.`.